### PR TITLE
Update/controller to v2.4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,18 @@
+name: Generate terraform docs
+on:
+  - pull_request
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs inside the README.md and push changes back to PR branch
+      uses: terraform-docs/gh-actions@v1.0.0
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,20 @@
+# Version 3.0.0 - 19-05-2022
+## BREAKING CHANGES
+```This version no longer works with Kubernetes version 1.18 and below due to changes in the API for Ingress resources from 1.19 and onwards```
+
+### Upgraded
+- Helm chart for the loadbalancer controller upgraded to version: [2.4.1](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.4.1)
+- Upgraded values yaml for the loadbalancer
+- Custom resource definitions updated to new version: [0.5.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/ec3418567841c1d36caf493c76105baf5e337b98/helm/aws-load-balancer-controller/crds/crds.yaml) 
+
+### Added
+- Terraform-docs inside the Readme.
+- Added description for all the variables.
+- Added description for all the outputs.
+- Added variable `force_update` for the helm chart.
+- Added Changelog to repository.
+
+
+# Version 2.0.1 - 14-04-2022
+### Upgraded
+- removed usage of `template_file` in favor of `templatefile`

--- a/README.md
+++ b/README.md
@@ -133,3 +133,58 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_iam_policy_arn"></a> [aws\_iam\_policy\_arn](#output\_aws\_iam\_policy\_arn) | The IAM policy ARN for the ALB Ingress Controller. |
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.5.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.2.4 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.5.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 1.2.4 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.7.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.13 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.alb-ingress-controller-iam-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.alb-ingress-controller-iam-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.alb-ingress-controller-iam-role-policy-attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.aws-load-balancer-controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubectl_manifest.crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubernetes_cluster_role.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role_binding.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_service_account.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID. | `string` | n/a | yes |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | The name of the EKS cluster. | `string` | n/a | yes |
+| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force Helm resource update through delete/recreate if needed. | `bool` | `false` | no |
+| <a name="input_oidc_host_path"></a> [oidc\_host\_path](#input\_oidc\_host\_path) | The host path of the OIDC provider. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_iam_policy_arn"></a> [aws\_iam\_policy\_arn](#output\_aws\_iam\_policy\_arn) | The IAM policy ARN for the ALB Ingress Controller. |
+<!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
-# terraform-aws-eks-alb-ingress
+# Terraform-aws-eks-alb-ingress
 
 This module requires our [openid connect module](https://github.com/kabisa/terraform-aws-eks-openid-connect)
 
-Example usage:
+# Upgrading the module from version 2.1 and lower:
+Due to changes made in the helm chart you will need to recreate the entire stack.
+
+Snippet from the [controller repo](https://github.com/kubernetes-sigs/aws-load-balancer-controller/):
+```
+The new controller is backwards compatible with the existing ingress objects. However, it will NOT coexist with the older aws-alb-ingress-controller. 
+
+The old controller must be uninstalled completely before installing the new version.
+```
+
+# Example usage:
 
 ```hcl-terraform
 module "eks_openid_connect" {
@@ -68,5 +78,58 @@ resource "kubernetes_ingress" "my-ingress" {
     }
   }
 }
-
 ```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.5.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.2.4 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.5.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 1.2.4 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.7.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.13 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy.alb-ingress-controller-iam-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.alb-ingress-controller-iam-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.alb-ingress-controller-iam-role-policy-attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.aws-load-balancer-controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubectl_manifest.crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubernetes_cluster_role.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
+| [kubernetes_cluster_role_binding.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
+| [kubernetes_service_account.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID. | `string` | n/a | yes |
+| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | The name of the EKS cluster. | `string` | n/a | yes |
+| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. | `bool` | `false` | no |
+| <a name="input_oidc_host_path"></a> [oidc\_host\_path](#input\_oidc\_host\_path) | The host path of the OIDC provider. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region. | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_iam_policy_arn"></a> [aws\_iam\_policy\_arn](#output\_aws\_iam\_policy\_arn) | The IAM policy ARN for the ALB Ingress Controller. |

--- a/README.md
+++ b/README.md
@@ -80,59 +80,6 @@ resource "kubernetes_ingress" "my-ingress" {
 }
 ```
 
-## Requirements
-
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.5.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.2.4 |
-| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 1.13 |
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.5.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 1.2.4 |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.7.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 1.13 |
-
-## Modules
-
-No modules.
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_iam_policy.alb-ingress-controller-iam-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.alb-ingress-controller-iam-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.alb-ingress-controller-iam-role-policy-attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [helm_release.aws-load-balancer-controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubectl_manifest.crds](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
-| [kubernetes_cluster_role.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role) | resource |
-| [kubernetes_cluster_role_binding.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
-| [kubernetes_service_account.alb_ingress_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
-| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | The AWS account ID. | `string` | n/a | yes |
-| <a name="input_eks_cluster_name"></a> [eks\_cluster\_name](#input\_eks\_cluster\_name) | The name of the EKS cluster. | `string` | n/a | yes |
-| <a name="input_force_update"></a> [force\_update](#input\_force\_update) | Force resource update through delete/recreate if needed. | `bool` | `false` | no |
-| <a name="input_oidc_host_path"></a> [oidc\_host\_path](#input\_oidc\_host\_path) | The host path of the OIDC provider. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | The AWS region. | `string` | n/a | yes |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID. | `string` | n/a | yes |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_aws_iam_policy_arn"></a> [aws\_iam\_policy\_arn](#output\_aws\_iam\_policy\_arn) | The IAM policy ARN for the ALB Ingress Controller. |
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This module requires our [openid connect module](https://github.com/kabisa/terra
 # Upgrading the module from version 2.1 and lower:
 Due to changes made in the helm chart you will need to recreate the entire stack.
 
-Snippet from the [controller repo](https://github.com/kubernetes-sigs/aws-load-balancer-controller/):
+Snippet from the [controller repo](https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/helm/aws-load-balancer-controller#upgrade):
 ```
 The new controller is backwards compatible with the existing ingress objects. However, it will NOT coexist with the older aws-alb-ingress-controller. 
 

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "kubectl_manifest" "crds" {
   yaml_body = file("${path.module}/yamls/crds.yaml")
 }
 
-# V 2.1
+# V 2.4.1
 # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/
 # helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name>
 resource "helm_release" "aws-load-balancer-controller" {
@@ -44,7 +44,7 @@ resource "helm_release" "aws-load-balancer-controller" {
   namespace  = "kube-system"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  version    = "1.1.4" # appVersion: v2.1.2
+  version    = "1.4.1" # appVersion: v2.4.1
 
   values = [
     templatefile(

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,14 @@ resource "kubectl_manifest" "crds" {
 # https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/
 # helm install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=<cluster-name>
 resource "helm_release" "aws-load-balancer-controller" {
-  depends_on = [kubectl_manifest.crds]
-  name       = "aws-load-balancer-controller"
-  namespace  = "kube-system"
-  repository = "https://aws.github.io/eks-charts"
-  chart      = "aws-load-balancer-controller"
-  version    = "1.4.1" # appVersion: v2.4.1
+  depends_on   = [kubectl_manifest.crds]
+  name         = "aws-load-balancer-controller"
+  namespace    = "kube-system"
+  repository   = "https://aws.github.io/eks-charts"
+  chart        = "aws-load-balancer-controller"
+  version      = "1.4.1" # appVersion: v2.4.1
+  #This defaults to false, recreation is required when upgrading the module from version 2.1 and lower
+  force_update = var.force_update
 
   values = [
     templatefile(

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "aws_iam_policy_arn" {
   value = aws_iam_policy.alb-ingress-controller-iam-policy.arn
+  description = "The IAM policy ARN for the ALB Ingress Controller."
 }

--- a/policy.tf
+++ b/policy.tf
@@ -1,5 +1,8 @@
-# Generated based on https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/v2.1.2/docs/install/iam_policy.json
-# Tool used: https://github.com/flosell/iam-policy-json-to-terraform
+# Generated based on: https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json
+# Commit version:     https://github.com/kubernetes-sigs/aws-load-balancer-controller/commit/cc59a8c6bd521f2e334b81cb0132652fbb3f5d9d
+# Tool used:          https://github.com/flosell/iam-policy-json-to-terraform
+# Matches chart:      version: 1.4.1
+#                     appVersion: v2.4.1
 
 
 data "aws_iam_policy_document" "policy" {
@@ -7,13 +10,27 @@ data "aws_iam_policy_document" "policy" {
     sid       = ""
     effect    = "Allow"
     resources = ["*"]
+    actions   = ["iam:CreateServiceLinkedRole"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:AWSServiceName"
+      values   = ["elasticloadbalancing.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = ""
+    effect    = "Allow"
+    resources = ["*"]
 
     actions = [
-      "iam:CreateServiceLinkedRole",
       "ec2:DescribeAccountAttributes",
       "ec2:DescribeAddresses",
+      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInternetGateways",
       "ec2:DescribeVpcs",
+      "ec2:DescribeVpcPeeringConnections",
       "ec2:DescribeSubnets",
       "ec2:DescribeSecurityGroups",
       "ec2:DescribeInstances",
@@ -85,15 +102,15 @@ data "aws_iam_policy_document" "policy" {
     actions   = ["ec2:CreateTags"]
 
     condition {
-      test     = "StringEquals"
-      variable = "ec2:CreateAction"
-      values   = ["CreateSecurityGroup"]
-    }
-
-    condition {
       test     = "Null"
       variable = "aws:RequestTag/elbv2.k8s.aws/cluster"
       values   = ["false"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateSecurityGroup"]
     }
   }
 
@@ -194,6 +211,23 @@ data "aws_iam_policy_document" "policy" {
       variable = "aws:ResourceTag/elbv2.k8s.aws/cluster"
       values   = ["false"]
     }
+  }
+
+  statement {
+    sid    = ""
+    effect = "Allow"
+
+    resources = [
+      "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+      "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+      "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+      "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*",
+    ]
+
+    actions = [
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:RemoveTags",
+    ]
   }
 
   statement {

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,24 @@
 variable "eks_cluster_name" {
   type = string
+  description = "The name of the EKS cluster."
 }
 
 variable "region" {
   type = string
+  description = "The AWS region."
 }
 
 variable "oidc_host_path" {
   type = string
+  description = "The host path of the OIDC provider."
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+  type = string
+  description = "The VPC ID."
+}
 
 variable "account_id" {
   type = string
+  description = "The AWS account ID."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,3 +22,9 @@ variable "account_id" {
   type = string
   description = "The AWS account ID."
 }
+
+variable "force_update" {
+  type = bool
+  default = false
+  description = "Force resource update through delete/recreate if needed."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,5 +26,5 @@ variable "account_id" {
 variable "force_update" {
   type = bool
   default = false
-  description = "Force resource update through delete/recreate if needed."
+  description = "Force Helm resource update through delete/recreate if needed."
 }

--- a/yamls/crds.yaml
+++ b/yamls/crds.yaml
@@ -1,187 +1,476 @@
-# Source https://github.com/aws/eks-charts/blob/master/stable/aws-load-balancer-controller/crds/crds.yaml
-# Commit version: https://github.com/aws/eks-charts/commit/d49b1aad90374dca2f24626edad8bc8283f6742f
-# Matches chart: - version: 0.1.4
-#                - appVersion: v2.0.0
+# Source:         https://github.com/aws/eks-charts/blob/master/stable/aws-load-balancer-controller/crds/crds.yaml
+# Commit version: https://github.com/aws/eks-charts/commit/93fa739be6d96e15ec1735a50ace40eefb2ec2c6
+# Matches chart:  version: 1.4.1
+#                 appVersion: v2.4.1
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: ingressclassparams.elbv2.k8s.aws
+spec:
+  group: elbv2.k8s.aws
+  names:
+    kind: IngressClassParams
+    listKind: IngressClassParamsList
+    plural: ingressclassparams
+    singular: ingressclassparams
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: The Ingress Group name
+      jsonPath: .spec.group.name
+      name: GROUP-NAME
+      type: string
+    - description: The AWS Load Balancer scheme
+      jsonPath: .spec.scheme
+      name: SCHEME
+      type: string
+    - description: The AWS Load Balancer ipAddressType
+      jsonPath: .spec.ipAddressType
+      name: IP-ADDRESS-TYPE
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IngressClassParams is the Schema for the IngressClassParams API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IngressClassParamsSpec defines the desired state of IngressClassParams
+            properties:
+              group:
+                description: Group defines the IngressGroup for all Ingresses that belong to IngressClass with this IngressClassParams.
+                properties:
+                  name:
+                    description: Name is the name of IngressGroup.
+                    type: string
+                required:
+                - name
+                type: object
+              ipAddressType:
+                description: IPAddressType defines the ip address type for all Ingresses that belong to IngressClass with this IngressClassParams.
+                enum:
+                - ipv4
+                - dualstack
+                type: string
+              loadBalancerAttributes:
+                description: LoadBalancerAttributes define the custom attributes to LoadBalancers for all Ingress that that belong to IngressClass with this IngressClassParams.
+                items:
+                  description: Attributes defines custom attributes on resources.
+                  properties:
+                    key:
+                      description: The key of the attribute.
+                      type: string
+                    value:
+                      description: The value of the attribute.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector restrict the namespaces of Ingresses that are allowed to specify the IngressClass with this IngressClassParams. * if absent or present but empty, it selects all namespaces.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              scheme:
+                description: Scheme defines the scheme for all Ingresses that belong to IngressClass with this IngressClassParams.
+                enum:
+                - internal
+                - internet-facing
+                type: string
+              tags:
+                description: Tags defines list of Tags on AWS resources provisioned for Ingresses that belong to IngressClass with this IngressClassParams.
+                items:
+                  description: Tag defines a AWS Tag on resources.
+                  properties:
+                    key:
+                      description: The key of the tag.
+                      type: string
+                    value:
+                      description: The value of the tag.
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: targetgroupbindings.elbv2.k8s.aws
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.serviceRef.name
-    description: The Kubernetes Service's name
-    name: SERVICE-NAME
-    type: string
-  - JSONPath: .spec.serviceRef.port
-    description: The Kubernetes Service's port
-    name: SERVICE-PORT
-    type: string
-  - JSONPath: .spec.targetType
-    description: The AWS TargetGroup's TargetType
-    name: TARGET-TYPE
-    type: string
-  - JSONPath: .spec.targetGroupARN
-    description: The AWS TargetGroup's Amazon Resource Name
-    name: ARN
-    priority: 1
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: AGE
-    type: date
   group: elbv2.k8s.aws
   names:
-    categories:
-    - all
     kind: TargetGroupBinding
     listKind: TargetGroupBindingList
     plural: targetgroupbindings
     singular: targetgroupbinding
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: TargetGroupBinding is the Schema for the TargetGroupBinding API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
-          properties:
-            networking:
-              description: networking provides the networking setup for ELBV2 LoadBalancer
-                to access targets in TargetGroup.
-              properties:
-                ingress:
-                  description: List of ingress rules to allow ELBV2 LoadBalancer to
-                    access targets in TargetGroup.
-                  items:
-                    properties:
-                      from:
-                        description: List of peers which should be able to access
-                          the targets in TargetGroup. At least one NetworkingPeer
-                          should be specified.
-                        items:
-                          description: NetworkingPeer defines the source/destination
-                            peer for networking rules.
-                          properties:
-                            ipBlock:
-                              description: IPBlock defines an IPBlock peer. If specified,
-                                none of the other fields can be set.
-                              properties:
-                                cidr:
-                                  description: CIDR is the network CIDR. Both IPV4
-                                    or IPV6 CIDR are accepted.
-                                  type: string
-                              required:
-                              - cidr
-                              type: object
-                            securityGroup:
-                              description: SecurityGroup defines a SecurityGroup peer.
-                                If specified, none of the other fields can be set.
-                              properties:
-                                groupID:
-                                  description: GroupID is the EC2 SecurityGroupID.
-                                  type: string
-                              required:
-                              - groupID
-                              type: object
-                          type: object
-                        type: array
-                      ports:
-                        description: List of ports which should be made accessible
-                          on the targets in TargetGroup. If ports is empty or unspecified,
-                          it defaults to all ports with TCP.
-                        items:
-                          properties:
-                            port:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              description: The port which traffic must match. When
-                                NodePort endpoints(instance TargetType) is used, this
-                                must be a numerical port. When Port endpoints(ip TargetType)
-                                is used, this can be either numerical or named port
-                                on pods. if port is unspecified, it defaults to all
-                                ports.
-                              x-kubernetes-int-or-string: true
-                            protocol:
-                              description: The protocol which traffic must match.
-                                If protocol is unspecified, it defaults to TCP.
-                              enum:
-                              - TCP
-                              - UDP
-                              type: string
-                          type: object
-                        type: array
-                    required:
-                    - from
-                    - ports
-                    type: object
-                  type: array
-              type: object
-            serviceRef:
-              description: serviceRef is a reference to a Kubernetes Service and ServicePort.
-              properties:
-                name:
-                  description: Name is the name of the Service.
-                  type: string
-                port:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  description: Port is the port of the ServicePort.
-                  x-kubernetes-int-or-string: true
-              required:
-              - name
-              - port
-              type: object
-            targetGroupARN:
-              description: targetGroupARN is the Amazon Resource Name (ARN) for the
-                TargetGroup.
-              type: string
-            targetType:
-              description: targetType is the TargetType of TargetGroup. If unspecified,
-                it will be automatically inferred.
-              enum:
-              - instance
-              - ip
-              type: string
-          required:
-          - serviceRef
-          - targetGroupARN
-          type: object
-        status:
-          description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
-          properties:
-            observedGeneration:
-              description: The generation observed by the TargetGroupBinding controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              networking:
+                description: networking provides the networking setup for ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: false
-  - name: v1beta1
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The Kubernetes Service's name
+      jsonPath: .spec.serviceRef.name
+      name: SERVICE-NAME
+      type: string
+    - description: The Kubernetes Service's port
+      jsonPath: .spec.serviceRef.port
+      name: SERVICE-PORT
+      type: string
+    - description: The AWS TargetGroup's TargetType
+      jsonPath: .spec.targetType
+      name: TARGET-TYPE
+      type: string
+    - description: The AWS TargetGroup's Amazon Resource Name
+      jsonPath: .spec.targetGroupARN
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TargetGroupBinding is the Schema for the TargetGroupBinding API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TargetGroupBindingSpec defines the desired state of TargetGroupBinding
+            properties:
+              ipAddressType:
+                description: ipAddressType specifies whether the target group is of type IPv4 or IPv6. If unspecified, it will be automatically inferred.
+                enum:
+                - ipv4
+                - ipv6
+                type: string
+              networking:
+                description: networking defines the networking rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                properties:
+                  ingress:
+                    description: List of ingress rules to allow ELBV2 LoadBalancer to access targets in TargetGroup.
+                    items:
+                      description: NetworkingIngressRule defines a particular set of traffic that is allowed to access TargetGroup's targets.
+                      properties:
+                        from:
+                          description: List of peers which should be able to access the targets in TargetGroup. At least one NetworkingPeer should be specified.
+                          items:
+                            description: NetworkingPeer defines the source/destination peer for networking rules.
+                            properties:
+                              ipBlock:
+                                description: IPBlock defines an IPBlock peer. If specified, none of the other fields can be set.
+                                properties:
+                                  cidr:
+                                    description: CIDR is the network CIDR. Both IPV4 or IPV6 CIDR are accepted.
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              securityGroup:
+                                description: SecurityGroup defines a SecurityGroup peer. If specified, none of the other fields can be set.
+                                properties:
+                                  groupID:
+                                    description: GroupID is the EC2 SecurityGroupID.
+                                    type: string
+                                required:
+                                - groupID
+                                type: object
+                            type: object
+                          type: array
+                        ports:
+                          description: List of ports which should be made accessible on the targets in TargetGroup. If ports is empty or unspecified, it defaults to all ports with TCP.
+                          items:
+                            description: NetworkingPort defines the port and protocol for networking rules.
+                            properties:
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port which traffic must match. When NodePort endpoints(instance TargetType) is used, this must be a numerical port. When Port endpoints(ip TargetType) is used, this can be either numerical or named port on pods. if port is unspecified, it defaults to all ports.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                description: The protocol which traffic must match. If protocol is unspecified, it defaults to TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - from
+                      - ports
+                      type: object
+                    type: array
+                type: object
+              nodeSelector:
+                description: node selector for instance type target groups to only register certain nodes
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              serviceRef:
+                description: serviceRef is a reference to a Kubernetes Service and ServicePort.
+                properties:
+                  name:
+                    description: Name is the name of the Service.
+                    type: string
+                  port:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: Port is the port of the ServicePort.
+                    x-kubernetes-int-or-string: true
+                required:
+                - name
+                - port
+                type: object
+              targetGroupARN:
+                description: targetGroupARN is the Amazon Resource Name (ARN) for the TargetGroup.
+                minLength: 1
+                type: string
+              targetType:
+                description: targetType is the TargetType of TargetGroup. If unspecified, it will be automatically inferred.
+                enum:
+                - instance
+                - ip
+                type: string
+            required:
+            - serviceRef
+            - targetGroupARN
+            type: object
+          status:
+            description: TargetGroupBindingStatus defines the observed state of TargetGroupBinding
+            properties:
+              observedGeneration:
+                description: The generation observed by the TargetGroupBinding controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/yamls/loadbalancer-values.yaml
+++ b/yamls/loadbalancer-values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon/aws-load-balancer-controller
-  tag: v2.1.2
+  tag: v2.4.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,13 +57,22 @@ resources: {}
 
 # Leverage a PriorityClass to ensure the controller will survive resource shortages
 # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-priorityClassName: ""
+priorityClassName: system-cluster-critical
 
 nodeSelector: {}
 
 tolerations: []
 
 affinity: {}
+
+updateStrategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 1
+
+# serviceAnnotations contains annotations to be added to the provisioned webhook service resource
+serviceAnnotations: {}
 
 podAnnotations: {}
 
@@ -76,11 +85,33 @@ enableCertManager: false
 # ingresses without ingress class annotation and ingresses of type alb
 ingressClass: alb
 
+# ingressClassParams specify the IngressCLassParams that enforce settings for a set of Ingresses when using with ingress Controller.
+ingressClassParams:
+  create: true
+  # The name of ingressClassParams resource will be referred in ingressClass
+  name:
+  spec: {}
+    # You always can set specifications in `helm install` command through `--set` or `--set-string`
+    # If you do want to specify specifications in values.yaml, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'spec:'.
+    # namespaceSelector:
+    #   matchLabels:
+    # group:
+    # scheme:
+    # ipAddressType:
+    # tags:
+
+# To use IngressClass resource instead of annotation, before you need to install the IngressClass resource pointing to controller.
+# If specified as true, the IngressClass resource will be created.
+createIngressClassResource: true
+
 # The AWS region for the kubernetes cluster. Set to use KIAM or kube2iam for example.
 region: "${region}"
 
 # The VPC ID for the Kubernetes cluster. Set this manually when your pods are unable to use the metadata service to determine this automatically
 vpcId: "${vpc_id}"
+# Custom AWS API Endpoints (serviceID1=URL1,serviceID2=URL2)
+awsApiEndpoints:
 
 # Maximum retries for AWS APIs (default 10)
 awsMaxRetries:
@@ -109,17 +140,38 @@ metricsBindAddr: ""
 # The TCP port the Webhook server binds to. (default 9443)
 webhookBindPort:
 
+# webhookTLS specifies TLS cert/key for the webhook
+webhookTLS:
+  caCert:
+  cert:
+  key:
+
+# keepTLSSecret specifies whether to reuse existing TLS secret for chart upgrade
+keepTLSSecret: true
+
 # Maximum number of concurrently running reconcile loops for service (default 3)
 serviceMaxConcurrentReconciles:
 
 # Maximum number of concurrently running reconcile loops for targetGroupBinding
 targetgroupbindingMaxConcurrentReconciles:
 
+# Maximum duration of exponential backoff for targetGroupBinding reconcile failures
+targetgroupbindingMaxExponentialBackoffDelay:
+
 # Period at which the controller forces the repopulation of its local object stores. (default 1h0m0s)
 syncPeriod:
 
 # Namespace the controller watches for updates to Kubernetes objects, If empty, all namespaces are watched.
 watchNamespace:
+
+# disableIngressClassAnnotation disables the usage of kubernetes.io/ingress.class annotation, false by default
+disableIngressClassAnnotation:
+
+# disableIngressGroupNameAnnotation disables the usage of alb.ingress.kubernetes.io/group.name annotation, false by default
+disableIngressGroupNameAnnotation:
+
+# defaultSSLPolicy specifies the default SSL policy to use for TLS/HTTPS listeners
+defaultSSLPolicy:
 
 # Liveness probe configuration for the controller
 livenessProbe:
@@ -145,6 +197,13 @@ env:
 # recommended if using the Amazon VPC CNI plugin.
 hostNetwork: false
 
+# Specifies the dnsPolicy that should be used for pods in the deployment
+#
+# This may need to be used to be changed given certain conditions. For instance, if one uses the cilium CNI
+# with certain settings, one may need to set `hostNetwork: true` and webhooks won't work unless `dnsPolicy`
+# is set to `ClusterFirstWithHostNet`. See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
+dnsPolicy:
+
 # extraVolumeMounts are the additional volume mounts. This enables setting up IRSA on non-EKS Kubernetes cluster
 extraVolumeMounts:
   # - name: aws-iam-token
@@ -167,6 +226,49 @@ defaultTags: {}
   # default_tag1: value1
   # default_tag2: value2
 
+# podDisruptionBudget specifies the disruption budget for the controller pods.
+# Disruption budget will be configured only when the replicaCount is greater than 1
 podDisruptionBudget: {}
 #  maxUnavailable: 1
 
+# externalManagedTags is the list of tag keys on AWS resources that will be managed externally
+externalManagedTags: []
+
+# enableEndpointSlices enables k8s EndpointSlices for IP targets instead of Endpoints (default false)
+enableEndpointSlices:
+
+# enableBackendSecurityGroup enables shared security group for backend traffic (default true)
+enableBackendSecurityGroup:
+
+# backendSecurityGroup specifies backend security group id (default controller auto create backend security group)
+backendSecurityGroup:
+
+# disableRestrictedSecurityGroupRules specifies whether to disable creating port-range restricted security group rules for traffic
+disableRestrictedSecurityGroupRules:
+
+# objectSelector for webhook
+objectSelector:
+  matchExpressions:
+  # - key: <key>
+  #   operator: <operator>
+  #   values:
+  #   - <value>
+  matchLabels:
+  #   key: value
+
+serviceMonitor:
+  # Specifies whether a service monitor should be created
+  enabled: false
+  # Labels to add to the service account
+  additionalLabels: {}
+  # Prometheus scrape interval
+  interval: 1m
+
+# clusterSecretsPermissions lets you configure RBAC permissions for secret resources
+# Access to secrets resource is required only if you use the OIDC feature, and instead of
+# enabling access to all secrets, we recommend configuring namespaced role/rolebinding.
+# This option is for backwards compatibility only, and will potentially be deprecated in future.
+clusterSecretsPermissions:
+  # allowAllSecrets allows the controller to access all secrets in the cluster.
+  # This is to get backwards compatible behavior, but *NOT* recommended for security reasons
+  allowAllSecrets: false


### PR DESCRIPTION
The previous controller we used dates back to feb 2021. This updates the controller to the latest version.

**Adds new version of IAM policy**
  Since version 2.2.0 of the helm chart the IAM policy needs additions.
 
**Adds new version of CRDS yaml**
    Since version 2.2.0 of the helm chart uses a different `CustomResourceDefinition` to enable the mapping.
    This file is updated to reflect these changes.

**Adds new values for the loadbalancer**  
    The values file has been brought up to speed
    with the values file for version 2.4.1

**Updated reference for the helm chart version**
    The helm chart now refers to version 2.4.1.
    This includes a newer image with security fixes etc.
    Additionally this version will no longer work for k8s 1.18 (EOL).
    This is due to changes in the ingress API from k8s 1.19 and onwards.
    
**Added descriptions to vars and outputs**

**Add variable to force updating the chart**
    This variable defaults to false. User can overwrite it to force it.
    
**Updates to readme**
    Due to changes in the helm chart additional steps are required.
    Additionally Terraform-docs output is added
    
**Updates reference link**
    The link pointed to the root of the repo, now it points to the specific
    readme inside the repo.
    
 **Added changelog**
    This module did not have a changelog, we need to have this for documentation's sake