### PR TITLE
Add automounting of the serviceaccount token

### DIFF
--- a/k8s-resources.tf
+++ b/k8s-resources.tf
@@ -55,4 +55,5 @@ resource "kubernetes_service_account" "alb_ingress_controller" {
       "eks.amazonaws.com/role-arn" = "arn:aws:iam::${var.account_id}:role/${aws_iam_role.alb-ingress-controller-iam-role.name}"
     }
   }
+  automount_service_account_token = true
 }


### PR DESCRIPTION
This is an optional boolean, on newer versions of terraform and the
kubernetes provider this default to `true`. However older versions don't
have this set to true and therefore default to `false`

This ultimately result in deployments failing due to them not being able
to find the token.

By setting it to `true` we can ensure it's mounted no matter what
version of terraform and kubernetes provider is used.