### PR TITLE
fix: updates serfice account token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The nodes should re-register to the Target Group(s) and your application should 
 
 ```hcl
 module "eks_openid_connect" {
-  source = "git@github.com:kabisa/terraform-aws-eks-openid-connect.git?ref=1.0"
+  source = "git@github.com:kabisa/terraform-aws-eks-openid-connect.git?ref=1.4.0"
   # tf 0.13
   # depends_on              = [module.eks]
   cluster_oidc_issuer_url = module.eks.cluster_oidc_issuer_url
@@ -40,7 +40,7 @@ module "eks_openid_connect" {
 }
 
 module "alb" {
-  source = "git@github.com:kabisa/terraform-aws-eks-alb-ingress.git?ref=1.0"
+  source = "git@github.com:kabisa/terraform-aws-eks-alb-ingress.git?ref=3.1.0"
   account_id = var.account_id
   eks_cluster_name = var.eks_cluster_name
   oidc_host_path = module.eks_openid_connect.oidc_host_path

--- a/k8s-resources.tf
+++ b/k8s-resources.tf
@@ -42,6 +42,12 @@ resource "kubernetes_cluster_role" "alb_ingress_controller" {
   }
 }
 
+resource "kubernetes_secret" "alb_ingress_controller" {
+  metadata {
+    name = "alb-ingress-controller"
+  }
+}
+
 resource "kubernetes_service_account" "alb_ingress_controller" {
   metadata {
     name      = "alb-ingress-controller"
@@ -55,5 +61,9 @@ resource "kubernetes_service_account" "alb_ingress_controller" {
       "eks.amazonaws.com/role-arn" = "arn:aws:iam::${var.account_id}:role/${aws_iam_role.alb-ingress-controller-iam-role.name}"
     }
   }
-  automount_service_account_token = true
+  secret {
+    name = kubernetes_secret.alb_ingress_controller.name
+  }
+
+  depends_on = [kubernetes_secret.alb_ingress_controller]
 }


### PR DESCRIPTION
This generates a token secret for the service account in compliance with kubernetes versions greater than 1.24. I also updated the versions in the README for folks who are lazy like me and just copy the thing and use it without checking it...

## What

Explain what changes inside the code, this can be as simple or complicated as you want as long as it's clear

## Why

Explain why these things are changes. This explanation is for your colleagues and your future self.

## Code Review

Please consider the following checklist when reviewing this Pull Request.  
More background and details [here](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md).

* [ ] Does the code **actually solve** the problem it was meant to solve?
* [ ] Is the code covered by **unit tests**? **Integration tests**?
* [ ] Does anything here need **documentation**? (Focus on *why*, not *what.*)
* [ ] Does any of this code deal with **privacy sensitive information** or affects **security**? Ask an additional reviewer.
* [ ] Is the code easy to **understand** and **change** in the future?
* [ ] Is the same code or concept **duplicated**? Find a balance between DRYness and readability.
* [ ] Does the code reasonably adhere to the Kabisa [**coding standards**](https://github.com/kabisa/kabisa-guide/blob/master/organization/process/code-review/README.md)?
* [ ] Be kind.
